### PR TITLE
docs: add users field to chapter content attempts API documentation

### DIFF
--- a/docs/server-api/admin-apis/attempts.md
+++ b/docs/server-api/admin-apis/attempts.md
@@ -549,6 +549,21 @@ print(response.text)
 </Tabs>
 
 
+#### Response Fields
+
+|Name|Type|Description|
+|----|----|-----------|
+|count|integer|Total number of results|
+|next|string|URL for the next page of results|
+|previous|string|URL for the previous page of results|
+|per_page|integer|Number of results per page|
+|results|object|Object containing lists of content attempts and related data|
+|results.users|list|A list of unique users who attempted the content|
+|results.users[].id|integer|Unique ID of the user|
+|results.users[].username|string|Username of the user|
+|results.users[].email|string|Email of the user|
+|results.users[].phone|string|Phone number of the user|
+
 #### Response
 
 
@@ -634,6 +649,14 @@ print(response.text)
                 "created": "2024-12-05T11:50:41.384054+05:30",
                 "completed_on": null
             },
+        ],
+        "users": [
+            {
+                "id": 9,
+                "username": "john",
+                "email": "john@test.com",
+                "phone": "1234567890"
+            }
         ],
         "user_videos": [
             {

--- a/docs/server-api/admin-apis/attempts.md
+++ b/docs/server-api/admin-apis/attempts.md
@@ -549,20 +549,6 @@ print(response.text)
 </Tabs>
 
 
-#### Response Fields
-
-|Name|Type|Description|
-|----|----|-----------|
-|count|integer|Total number of results|
-|next|string|URL for the next page of results|
-|previous|string|URL for the previous page of results|
-|per_page|integer|Number of results per page|
-|results|object|Object containing lists of content attempts and related data|
-|results.users|list|A list of unique users who attempted the content|
-|results.users[].id|integer|Unique ID of the user|
-|results.users[].username|string|Username of the user|
-|results.users[].email|string|Email of the user|
-|results.users[].phone|string|Phone number of the user|
 
 #### Response
 


### PR DESCRIPTION
This PR updates the API documentation for:

`/api/v3/admin/chapter-content-attempts/
`
### Changes

- Added `users` field in the response documentation
- Documented `users` as a list of unique users who attempted the content
- Each user object includes:
  - id
  - username
  - email
  - phone
- Updated example JSON response to include the `users` field

**Todo**
https://3.basecamp.com/4160028/buckets/46740468/card_tables/cards/9815935535