### PR TITLE
Document viewer_id for the live viewer count

### DIFF
--- a/docs/video-embedding/getting-starting.md
+++ b/docs/video-embedding/getting-starting.md
@@ -38,3 +38,33 @@ Now you use copied iframe code in your code to embed the video.
 </body>
 </html>
 ```
+
+## Identifying viewers of a live stream
+
+For a live stream, the admin portal shows how many people are watching while it is on air.
+
+By default the player identifies a viewer with a cookie it sets on the embed page, so the count measures **devices**:
+
+| Situation | Counted as |
+| ----------- | ----------- |
+| Two tabs in the same browser | 1 |
+| Two different browsers on one device | 2 |
+| The same person on a phone and a laptop | 2 |
+
+Counting devices means nobody can inflate the number by opening more tabs, but it will read higher than your real audience if people watch on more than one device.
+
+If your users are signed in on your side, pass `viewer_id` in the embed URL. The count then measures **people**, and the same user on a phone and a laptop is counted once.
+
+```html
+<iframe width='560' height='315' src='https://<yoursiteurl>/embed/<video_id>/?access_token=<auth_token>&viewer_id=<your_user_id>' title='<video title>' frameborder='0' allow='accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture' allowfullscreen></iframe>
+```
+
+**Choosing a value**
+
+| Guidance | Why |
+| ----------- | ----------- |
+| Use the identifier your own system already has for that user | It has to stay the same across sessions and devices, or the same person is counted more than once |
+| Use an opaque ID rather than an email address or a name | The value travels in the embed URL, and URLs end up in browser history, referrer headers and server logs |
+| The same ID in two organizations is never confused | The value is hashed with a secret and scoped to your organization before it is used for counting, so TPStreams does not hold the raw ID in the viewer count |
+
+This parameter only affects the live viewer count. It has no effect on recorded videos, and it does not change playback or authorization in any way.


### PR DESCRIPTION
## Summary

- Adds a section to **Video embedding → Getting started** explaining how viewers of a live stream are identified.
- `viewer_id` has always been read by the embed view, but it appeared nowhere outside the code. Every integrator therefore got the cookie fallback without knowing there was a choice.
- Documents what the default actually measures — **devices, not people** — because "two tabs count as one" surprises people who expect otherwise.
- Documents what to pass to count people instead, and how to choose the value.

## What it says

The default identifies a viewer by a cookie on the embed page:

| Situation | Counted as |
|---|---|
| Two tabs in the same browser | 1 |
| Two browsers on one device | 2 |
| A phone and a laptop | 2 |

That is deliberate — it means nobody can inflate the number by opening tabs — but it reads high if people watch on more than one device. Passing `viewer_id` switches it to counting people.

## Guidance included

- Use the identifier your own system already has, so it stays stable across sessions and devices.
- Use an opaque ID, not an email or a name: the value travels in the embed URL, and URLs reach browser history, referrer headers and server logs.
- The value is hashed and scoped to the organization before it is used for counting, so the same ID in two organizations is never confused and TPStreams does not hold the raw ID in the viewer count.

Also states plainly that the parameter affects only the live viewer count — not recorded videos, playback or authorization — since a new URL parameter on the embed URL invites that question.